### PR TITLE
removed aling-items from service bottom to make sure all service items stay of same height

### DIFF
--- a/style.css
+++ b/style.css
@@ -278,7 +278,7 @@ p {
 }
 #services .service-bottom {
 	display: flex;
-	align-items: center;
+	/* align-items: center; */
 	justify-content: center;
 	flex-wrap: wrap;
 	margin-top: 50px;


### PR DESCRIPTION

when service items have different length of content, one with bigger content is higher and symmetry of service items is gone.  removing align-items: center from service bottom aligns all height to biggest content box ( I just commented it out for now). Alternatively, we can do align-items: stretch on _.service-bottom_  OR  align-self: stretch on _.service-item_ . Feel free to test these and implement change you like.


<img width="1348" alt="Screen Shot 2020-12-12 at 5 28 50 PM" src="https://user-images.githubusercontent.com/46854497/101983251-d4a54680-3c9f-11eb-9ddd-f8e7d2d8cabf.png">
